### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To install Shodan Server for Claude Desktop automatically via [Smithery](https:/
 npx -y @smithery/cli install @burtthecoder/mcp-shodan --client claude
 ```
 
+### Installing Manually
 1. Install the server globally via npm:
 ```bash
 npm install -g @burtthecoder/mcp-shodan

--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # Shodan MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@burtthecoder/mcp-shodan)](https://smithery.ai/server/@burtthecoder/mcp-shodan)
+
 A Model Context Protocol (MCP) server for querying the [Shodan API](https://shodan.io) and [Shodan CVEDB](https://cvedb.shodan.io). This server provides comprehensive access to Shodan's network intelligence and security services, including IP reconnaissance, DNS operations, vulnerability tracking, and device discovery. All tools provide structured, formatted output for easy analysis and integration.
 
 <a href="https://glama.ai/mcp/servers/79uakvikcj"><img width="380" height="200" src="https://glama.ai/mcp/servers/79uakvikcj/badge" /></a>
 
 ## Quick Start (Recommended)
+
+### Installing via Smithery
+
+To install Shodan Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@burtthecoder/mcp-shodan):
+
+```bash
+npx -y @smithery/cli install @burtthecoder/mcp-shodan --client claude
+```
 
 1. Install the server globally via npm:
 ```bash


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Shodan Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@burtthecoder/mcp-shodan

Let me know if any tweaks have to be made!