### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Configuration file location:
 
 3. Restart Claude Desktop
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/burtthecoder-mcp-shodan).
+
 ## Alternative Setup (From Source)
 
 If you prefer to run from source or need to modify the code:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/burtthecoder-mcp-shodan).