### PR TITLE
security: pin axios below compromised v1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "axios": "^1.7.8",
+    "axios": ">=1.7.8 <1.14.1",
     "dotenv": "^16.4.5",
     "fastmcp": "^3.33.0",
     "zod": "^3.23.0"


### PR DESCRIPTION
Pins axios below v1.14.1 to avoid supply chain attack (https://socket.dev/blog/axios-npm-package-compromised). axios@1.14.1 and axios@0.30.4 include a malicious dependency (plain-crypto-js) that deploys a RAT.